### PR TITLE
Sequence behind Magento_Quote

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -2,5 +2,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
     <module name="GetResponse_GetResponseIntegration" setup_version="20.3.6">
+        <sequence>
+            <module name="Magento_Quote" />                
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
`getresponse_cart_map` has a foreign key to the `quote` table installed by `Magento_Quote`. Adding this sequencing prevents this module from being installed before `Magento_Quote` on a fresh deploy and failing.